### PR TITLE
Fix typo in `firebase.js`

### DIFF
--- a/src/lib/firebase.js
+++ b/src/lib/firebase.js
@@ -15,6 +15,6 @@ var firebaseConfig = {
     appId: "1:725896730402:web:f571876e80350ab17ff77b"
 };
 
-let fb = firebase.initializeApp(config);
+let fb = firebase.initializeApp(firebaseConfig);
 
 export { fb };


### PR DESCRIPTION
The configuration variable is named `firebaseConfig` but we refer to `config` in this file on line 18. This PR simply uses the variable name as we defined.