### PR TITLE
Resolves Issue #10 (#32) - Estimate Next Purchase Date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4933,6 +4933,11 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
     },
+    "dayjs": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.21.tgz",
+      "integrity": "sha512-1kbWK0hziklUHkGgiKr7xm59KwAg/K3Tp7H/8X+f58DnNCwY3pKYjOCJpIlVs125FRBukGVZdKZojC073D0IeQ=="
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "dayjs": "^1.8.21",
     "firebase": "^7.7.0",
     "husky": "^3.1.0",
     "lint-staged": "^9.5.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "dayjs": "^1.8.21",
     "firebase": "^7.7.0",
     "husky": "^3.1.0",
     "lint-staged": "^9.5.0",

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -7,7 +7,8 @@ const Form = props => {
   const [name, setName] = useState("");
   const [frequency, setFrequency] = useState(0);
   const [date, setDate] = useState("");
-  const [numOfPurchases, setNumOfPurchases] = useState(0);
+  const [numOfPurchases] = useState(0);
+  const [lastEstimate] = useState(null);
 
   const handleSubmit = e => {
     e.preventDefault();
@@ -33,7 +34,8 @@ const Form = props => {
         name,
         frequency,
         date,
-        numOfPurchases
+        numOfPurchases,
+        lastEstimate
       };
 
       //setting the doc id to match the item name so it's easier to find a match

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -7,6 +7,7 @@ const Form = props => {
   const [name, setName] = useState("");
   const [frequency, setFrequency] = useState(0);
   const [date, setDate] = useState("");
+  const [numOfPurchases, setNumOfPurchases] = useState(0);
 
   const handleSubmit = e => {
     e.preventDefault();
@@ -31,7 +32,8 @@ const Form = props => {
       let data = {
         name,
         frequency,
-        date
+        date,
+        numOfPurchases
       };
 
       //setting the doc id to match the item name so it's easier to find a match

--- a/src/estimates.js
+++ b/src/estimates.js
@@ -3,17 +3,17 @@
  * Current purchase a tiny bit less weight than all previous purchases
  * @param {Number} lastEstimate The last stored purchase interval estimate
  * @param {Number} latestInterval The interval between the most recent and previous purchases
- * @param {Number} numberOfPurchases Total number of purchases for the item
+ * @param {Number} numOfPurchases Total number of purchases for the item
  */
-const calculateEstimate = (lastEstimate, latestInterval, numberOfPurchases) => {
+const calculateEstimate = (lastEstimate, latestInterval, numOfPurchases) => {
   if (isNaN(lastEstimate)) {
     lastEstimate = 14;
   }
 
   // FIXME algorithm doesn't work when there's only 1 purchase in the database
-  let previousFactor = lastEstimate * numberOfPurchases;
-  let latestFactor = latestInterval * (numberOfPurchases - 1);
-  let totalDivisor = numberOfPurchases * 2 - 1;
+  let previousFactor = lastEstimate * numOfPurchases;
+  let latestFactor = latestInterval * (numOfPurchases - 1);
+  let totalDivisor = numOfPurchases * 2 - 1;
   return (previousFactor + latestFactor) / totalDivisor;
 };
 

--- a/src/estimates.js
+++ b/src/estimates.js
@@ -1,0 +1,20 @@
+/**
+ * Calculate a weighted estimate for the interval until the next purchase
+ * Current purchase a tiny bit less weight than all previous purchases
+ * @param {Number} lastEstimate The last stored purchase interval estimate
+ * @param {Number} latestInterval The interval between the most recent and previous purchases
+ * @param {Number} numberOfPurchases Total number of purchases for the item
+ */
+const calculateEstimate = (lastEstimate, latestInterval, numberOfPurchases) => {
+  if (isNaN(lastEstimate)) {
+    lastEstimate = 14;
+  }
+
+  // FIXME algorithm doesn't work when there's only 1 purchase in the database
+  let previousFactor = lastEstimate * numberOfPurchases;
+  let latestFactor = latestInterval * (numberOfPurchases - 1);
+  let totalDivisor = numberOfPurchases * 2 - 1;
+  return (previousFactor + latestFactor) / totalDivisor;
+};
+
+export default calculateEstimate;


### PR DESCRIPTION
# Issue https://github.com/the-collab-lab/tcl-4-smart-shopping-list/issues/32

## Task
The main purpose of this issue was to calculate the number of days until the next purchase date and store it in the database
## Actions
- Created new state for the Number of Purchases and the Last Estimate, which are included with the other data when an item is added to the database
- Set the number of seconds in a day (86400) as a constant for use in multiple parts of the code
- Expanded the onChange to check if the item has already been purchased - if so, enters the purchase date for the first time and increments the number of purchases from zero to one
- If not, creates a new Last Estimate value based on user provided estimate (if 1st time through) or based on a calculated Next Purchase Date; also determines the most recent interval between purchases for the item; continues to increment by one each time through

## Notes
The date of the next purchase is calculated by a provided script - estimates.js

It's largely possible this solution could be heavily refactored, but due to time constraints, we're comfortable submitting what at least appears to be working successfully. :-)